### PR TITLE
Suggestion for new "callable" syntax on map

### DIFF
--- a/src/Domains/Network/Aggregates/ContactAggregate.php
+++ b/src/Domains/Network/Aggregates/ContactAggregate.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Domains\Network\Aggregates;
 
+use App\Models\Contact as ContactModel
 use Domains\Network\Entities\ContactEntity;
 use Domains\Network\Events\CompanyEntity;
 
@@ -23,5 +24,17 @@ final readonly class ContactAggregate
     public function contact(): ContactEntity
     {
         return $this->contact;
+    }
+
+    public static function fromContactModel(ContactModel $contact): ContactAggregate
+    {
+        return new ContactAggregate(
+            contact: ContactEntity::fromEloquent(
+                contact: $contact,
+            ),
+            company: CompanyEntity::fromEloquent(
+                company: $contact->company,
+            ),
+        );
     }
 }

--- a/src/Domains/Network/Services/ContactService.php
+++ b/src/Domains/Network/Services/ContactService.php
@@ -52,7 +52,7 @@ final readonly class ContactService
     public function all(): Collection
     {
         return $this->repository->all()->map(
-            ContactEntity::fromEloquent(...)
+            callback: ContactEntity::fromEloquent(...)
         );
     }
 

--- a/src/Domains/Network/Services/ContactService.php
+++ b/src/Domains/Network/Services/ContactService.php
@@ -36,14 +36,7 @@ final readonly class ContactService
             with: ['company'],
         );
 
-        return new ContactAggregate(
-            contact: ContactEntity::fromEloquent(
-                contact: $contact,
-            ),
-            company: CompanyEntity::fromEloquent(
-                company: $contact->company,
-            ),
-        );
+        return new ContactAggregate::fromContactModel($contact);
     }
 
     /**
@@ -52,7 +45,7 @@ final readonly class ContactService
     public function all(array $with = []): Collection
     {
         return $this->repository->all($with)->map(
-            callback: ContactAggregate::fromContact(...)
+            callback: ContactAggregate::fromContactModel(...)
         );
     }
 

--- a/src/Domains/Network/Services/ContactService.php
+++ b/src/Domains/Network/Services/ContactService.php
@@ -52,9 +52,7 @@ final readonly class ContactService
     public function all(): Collection
     {
         return $this->repository->all()->map(
-            callback: fn (Contact $contact): ContactEntity => ContactEntity::fromEloquent(
-                contact: $contact,
-            ),
+            ContactEntity::fromEloquent(...)
         );
     }
 


### PR DESCRIPTION
as per stream discussion - this is a new php callable syntax that would allow the "function" to be passed/called directly

Since the map's closure takes in the value as the 1st param, as does the fromEloquent static function on ContactEntity, we can reduce to the following format using the `...` splat/ellipses. this would be the equivenant of `[ContactEntity::class, 'fromEloquent']` or having, as you had already, the manual closure calling the method.